### PR TITLE
Fix check C to take the first non-space character instead of the first character

### DIFF
--- a/letter_scorer.js
+++ b/letter_scorer.js
@@ -118,7 +118,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
 	// CHECK C - Leading Capital
 	async function checkC() {
-		const FIRST_CHAR = LETTER_BOX.value[0];
+		const FIRST_CHAR = LETTER_BOX.value.match(/\S/)?.[0];
 		let score = 0;
 
 		if (FIRST_CHAR) {


### PR DESCRIPTION
Check C is currently bugged: it checks the first character instead of the intended behavior of checking the first non-space character. This PR fixes that.